### PR TITLE
Added support for request headers

### DIFF
--- a/EventSource4Net.Test/TestableEventSource.cs
+++ b/EventSource4Net.Test/TestableEventSource.cs
@@ -12,5 +12,9 @@ namespace EventSource4Net.Test
         {
 
         }
+        public TestableEventSource(Uri url, IWebRequesterFactory factory, Dictionary<string, string> headers) : base(url, factory, headers)
+        {
+
+        }
     }
 }

--- a/EventSource4Net.Test/WebRequesterFactoryTest.cs
+++ b/EventSource4Net.Test/WebRequesterFactoryTest.cs
@@ -18,7 +18,7 @@ namespace EventSource4Net.Test
         }
         public WebRequesterFactoryMock(ServiceResponseMock response)
         {
-             this.WebRequesterMock = new WebRequesterMock(response);
+            this.WebRequesterMock = new WebRequesterMock(response);
         }
         public IWebRequester Create()
         {
@@ -41,6 +41,7 @@ namespace EventSource4Net.Test
             return Task.Factory.StartNew<IServerResponse>(() =>
             {
                 GetCalled.Set();
+                Response.Headers = headers;
                 return Response;
             });
         }
@@ -52,6 +53,7 @@ namespace EventSource4Net.Test
         private Stream mStream;
         private StreamWriter mStreamWriter;
         private Uri mUrl;
+        private Dictionary<string, string> mHeaders;
         private HttpStatusCode mStatusCode;
 
         public ManualResetEvent StatusCodeCalled = new ManualResetEvent(false);
@@ -62,6 +64,7 @@ namespace EventSource4Net.Test
             mStatusCode = statusCode;
             mStream = new TestableStream();
             mStreamWriter = new StreamWriter(mStream);
+            mHeaders = new Dictionary<string, string>();
         }
 
         public System.Net.HttpStatusCode StatusCode
@@ -76,6 +79,18 @@ namespace EventSource4Net.Test
         public System.IO.Stream GetResponseStream()
         {
             return mStream;
+        }
+
+        public Dictionary<string, string> Headers
+        {
+            get
+            {
+                return mHeaders;
+            }
+            set
+            {
+                mHeaders = value;
+            }
         }
 
         public Uri ResponseUri

--- a/EventSource4Net.Test/WebRequesterFactoryTest.cs
+++ b/EventSource4Net.Test/WebRequesterFactoryTest.cs
@@ -36,7 +36,7 @@ namespace EventSource4Net.Test
             this.Response = response;
         }
 
-        public System.Threading.Tasks.Task<IServerResponse> Get(Uri url)
+        public System.Threading.Tasks.Task<IServerResponse> Get(Uri url, Dictionary<string, string> headers)
         {
             return Task.Factory.StartNew<IServerResponse>(() =>
             {
@@ -44,6 +44,7 @@ namespace EventSource4Net.Test
                 return Response;
             });
         }
+
     }
 
     class ServiceResponseMock : IServerResponse

--- a/EventSource4Net/ConnectedState.cs
+++ b/EventSource4Net/ConnectedState.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Net;
-using System.IO;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -17,7 +15,7 @@ namespace EventSource4Net
         private ServerSentEvent mSse = null;
         private string mRemainingText = string.Empty;   // the text that is not ended with a lineending char is saved for next call.
         private IServerResponse mResponse;
-        private Dictionary<string, string> headers;
+        private Dictionary<string, string> mHeaders;
 
         public EventSourceState State { get { return EventSourceState.OPEN; } }
 
@@ -25,10 +23,10 @@ namespace EventSource4Net
         {
             mResponse = response;
             mWebRequesterFactory = webRequesterFactory;
-            this.headers = headers;
+            mHeaders = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> msgReceived, CancellationToken cancelToken, Dictionary<string, string> headers)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> msgReceived, CancellationToken cancelToken)
         {
             int i = 0;
 
@@ -133,7 +131,7 @@ namespace EventSource4Net
                         //stream.Close();
                         //mResponse.Close();
                         //mResponse.Dispose();
-                        return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory, headers);
+                        return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory, mHeaders);
                     }
                 }
             });

--- a/EventSource4Net/ConnectedState.cs
+++ b/EventSource4Net/ConnectedState.cs
@@ -17,15 +17,18 @@ namespace EventSource4Net
         private ServerSentEvent mSse = null;
         private string mRemainingText = string.Empty;   // the text that is not ended with a lineending char is saved for next call.
         private IServerResponse mResponse;
+        private Dictionary<string, string> headers;
+
         public EventSourceState State { get { return EventSourceState.OPEN; } }
 
-        public ConnectedState(IServerResponse response, IWebRequesterFactory webRequesterFactory)
+        public ConnectedState(IServerResponse response, IWebRequesterFactory webRequesterFactory, Dictionary<string, string> headers)
         {
             mResponse = response;
             mWebRequesterFactory = webRequesterFactory;
+            this.headers = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> msgReceived, CancellationToken cancelToken)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> msgReceived, CancellationToken cancelToken, Dictionary<string, string> headers)
         {
             int i = 0;
 
@@ -130,7 +133,7 @@ namespace EventSource4Net
                         //stream.Close();
                         //mResponse.Close();
                         //mResponse.Dispose();
-                        return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory);
+                        return new DisconnectedState(mResponse.ResponseUri, mWebRequesterFactory, headers);
                     }
                 }
             });

--- a/EventSource4Net/ConnectingState.cs
+++ b/EventSource4Net/ConnectingState.cs
@@ -12,7 +12,7 @@ namespace EventSource4Net
 
         private Uri mUrl;
         private IWebRequesterFactory mWebRequesterFactory;
-        private Dictionary<string, string> headers;
+        private Dictionary<string, string> mHeaders;
 
         public EventSourceState State { get { return EventSourceState.CONNECTING; } }
         
@@ -22,13 +22,13 @@ namespace EventSource4Net
             if (webRequesterFactory == null) throw new ArgumentNullException("Factory cant be null");
             mUrl = url;
             mWebRequesterFactory = webRequesterFactory;
-            this.headers = headers;
+            mHeaders = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken, Dictionary<string, string> headers)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken)
         {
             IWebRequester requester = mWebRequesterFactory.Create();
-            var taskResp = requester.Get(mUrl, headers);
+            var taskResp = requester.Get(mUrl, mHeaders);
 
             return taskResp.ContinueWith<IConnectionState>(tsk => 
             {
@@ -37,7 +37,7 @@ namespace EventSource4Net
                     IServerResponse response = tsk.Result;
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
-                        return new ConnectedState(response, mWebRequesterFactory, headers);
+                        return new ConnectedState(response, mWebRequesterFactory, mHeaders);
                     }
                     else
                     {
@@ -45,7 +45,7 @@ namespace EventSource4Net
                     }
                 }
 
-                return new DisconnectedState(mUrl, mWebRequesterFactory, headers);
+                return new DisconnectedState(mUrl, mWebRequesterFactory, mHeaders);
             });
         }
     }

--- a/EventSource4Net/ConnectingState.cs
+++ b/EventSource4Net/ConnectingState.cs
@@ -1,10 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Net;
-using System.IO;
 using System.Threading;
 
 namespace EventSource4Net
@@ -15,20 +12,23 @@ namespace EventSource4Net
 
         private Uri mUrl;
         private IWebRequesterFactory mWebRequesterFactory;
+        private Dictionary<string, string> headers;
+
         public EventSourceState State { get { return EventSourceState.CONNECTING; } }
         
-        public ConnectingState(Uri url, IWebRequesterFactory webRequesterFactory)
+        public ConnectingState(Uri url, IWebRequesterFactory webRequesterFactory, Dictionary<string, string> headers)
         {
             if (url == null) throw new ArgumentNullException("Url cant be null");
             if (webRequesterFactory == null) throw new ArgumentNullException("Factory cant be null");
             mUrl = url;
             mWebRequesterFactory = webRequesterFactory;
+            this.headers = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken, Dictionary<string, string> headers)
         {
             IWebRequester requester = mWebRequesterFactory.Create();
-            var taskResp = requester.Get(mUrl);
+            var taskResp = requester.Get(mUrl, headers);
 
             return taskResp.ContinueWith<IConnectionState>(tsk => 
             {
@@ -37,7 +37,7 @@ namespace EventSource4Net
                     IServerResponse response = tsk.Result;
                     if (response.StatusCode == HttpStatusCode.OK)
                     {
-                        return new ConnectedState(response, mWebRequesterFactory);
+                        return new ConnectedState(response, mWebRequesterFactory, headers);
                     }
                     else
                     {
@@ -45,7 +45,7 @@ namespace EventSource4Net
                     }
                 }
 
-                return new DisconnectedState(mUrl, mWebRequesterFactory);
+                return new DisconnectedState(mUrl, mWebRequesterFactory, headers);
             });
         }
     }

--- a/EventSource4Net/DisconnectedState.cs
+++ b/EventSource4Net/DisconnectedState.cs
@@ -11,7 +11,7 @@ namespace EventSource4Net
     {
         private Uri mUrl;
         private IWebRequesterFactory mWebRequesterFactory;
-        private Dictionary<string, string> headers;
+        private Dictionary<string, string> mHeaders;
 
         public EventSourceState State
         {
@@ -23,15 +23,15 @@ namespace EventSource4Net
             if (url == null) throw new ArgumentNullException("Url cant be null");
             mUrl = url;
             mWebRequesterFactory = webRequesterFactory;
-            this.headers = headers;
+            mHeaders = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken, Dictionary<string, string> headers)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken)
         {
             if(cancelToken.IsCancellationRequested)
-                return Task.Factory.StartNew<IConnectionState>(() => { return new DisconnectedState(mUrl, mWebRequesterFactory, headers); });
+                return Task.Factory.StartNew<IConnectionState>(() => { return new DisconnectedState(mUrl, mWebRequesterFactory, mHeaders); });
             else
-                return Task.Factory.StartNew<IConnectionState>(() => { return new ConnectingState(mUrl, mWebRequesterFactory, headers); });
+                return Task.Factory.StartNew<IConnectionState>(() => { return new ConnectingState(mUrl, mWebRequesterFactory, mHeaders); });
         }
     }
 }

--- a/EventSource4Net/DisconnectedState.cs
+++ b/EventSource4Net/DisconnectedState.cs
@@ -11,24 +11,27 @@ namespace EventSource4Net
     {
         private Uri mUrl;
         private IWebRequesterFactory mWebRequesterFactory;
+        private Dictionary<string, string> headers;
+
         public EventSourceState State
         {
             get { return EventSourceState.CLOSED; }
         }
 
-        public DisconnectedState(Uri url, IWebRequesterFactory webRequesterFactory)
+        public DisconnectedState(Uri url, IWebRequesterFactory webRequesterFactory, Dictionary<string, string> headers)
         {
             if (url == null) throw new ArgumentNullException("Url cant be null");
             mUrl = url;
             mWebRequesterFactory = webRequesterFactory;
+            this.headers = headers;
         }
 
-        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken)
+        public Task<IConnectionState> Run(Action<ServerSentEvent> donothing, CancellationToken cancelToken, Dictionary<string, string> headers)
         {
             if(cancelToken.IsCancellationRequested)
-                return Task.Factory.StartNew<IConnectionState>(() => { return new DisconnectedState(mUrl, mWebRequesterFactory); });
+                return Task.Factory.StartNew<IConnectionState>(() => { return new DisconnectedState(mUrl, mWebRequesterFactory, headers); });
             else
-                return Task.Factory.StartNew<IConnectionState>(() => { return new ConnectingState(mUrl, mWebRequesterFactory); });
+                return Task.Factory.StartNew<IConnectionState>(() => { return new ConnectingState(mUrl, mWebRequesterFactory, headers); });
         }
     }
 }

--- a/EventSource4Net/EventSource.cs
+++ b/EventSource4Net/EventSource.cs
@@ -23,6 +23,9 @@ namespace EventSource4Net
         private CancellationToken mStopToken;
         private CancellationTokenSource mTokenSource = new CancellationTokenSource();
         private Dictionary<string, string> _headers;
+        private Uri url;
+        private IWebRequesterFactory factory;
+        private Dictionary<string, string> headers;
 
         private IConnectionState CurrentState
         {
@@ -63,6 +66,13 @@ namespace EventSource4Net
             Initialize(url, 0);
         }
 
+        public EventSource(Uri url, IWebRequesterFactory factory, Dictionary<string, string> headers)
+        {
+            _webRequesterFactory = factory;
+            _headers = headers;
+            Initialize(url, 0);
+        }
+
         private void Initialize(Uri url, int timeout)
         {
             _timeout = timeout;
@@ -91,7 +101,7 @@ namespace EventSource4Net
             if (mTokenSource.IsCancellationRequested && CurrentState.State == EventSourceState.CLOSED)
                 return;
 
-            mCurrentState.Run(this.OnEventReceived, mTokenSource.Token, _headers).ContinueWith(cs =>
+            mCurrentState.Run(this.OnEventReceived, mTokenSource.Token).ContinueWith(cs =>
             {
                 CurrentState = cs.Result;
                 Run();

--- a/EventSource4Net/EventSource.cs
+++ b/EventSource4Net/EventSource.cs
@@ -60,13 +60,13 @@ namespace EventSource4Net
         /// Constructor for testing purposes
         /// </summary>
         /// <param name="factory">The factory that generates the WebRequester to use.</param>
-        public EventSource(Uri url, IWebRequesterFactory factory)
+        protected EventSource(Uri url, IWebRequesterFactory factory)
         {
             _webRequesterFactory = factory;
             Initialize(url, 0);
         }
 
-        public EventSource(Uri url, IWebRequesterFactory factory, Dictionary<string, string> headers)
+        protected EventSource(Uri url, IWebRequesterFactory factory, Dictionary<string, string> headers)
         {
             _webRequesterFactory = factory;
             _headers = headers;

--- a/EventSource4Net/EventSource.cs
+++ b/EventSource4Net/EventSource.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Net;
-using System.IO;
-using System.Threading.Tasks;
 using System.Threading;
 
 namespace EventSource4Net
@@ -16,6 +12,8 @@ namespace EventSource4Net
         public event EventHandler<StateChangedEventArgs> StateChanged;
         public event EventHandler<ServerSentEventReceivedEventArgs> EventReceived;
 
+        public CancellationTokenSource CancellationToken { get; set; }
+
         private IWebRequesterFactory _webRequesterFactory = new WebRequesterFactory();
         private int _timeout = 0;
         public Uri Url { get; private set; }
@@ -24,6 +22,8 @@ namespace EventSource4Net
         private IConnectionState mCurrentState = null;
         private CancellationToken mStopToken;
         private CancellationTokenSource mTokenSource = new CancellationTokenSource();
+        private Dictionary<string, string> _headers;
+
         private IConnectionState CurrentState
         {
             get { return mCurrentState; }
@@ -47,11 +47,17 @@ namespace EventSource4Net
             Initialize(url, timeout);
         }
 
+        public EventSource(Uri url, Dictionary<string, string> headers, int timeout)
+        {
+            _headers = headers;
+            Initialize(url, timeout);
+        }
+
         /// <summary>
         /// Constructor for testing purposes
         /// </summary>
         /// <param name="factory">The factory that generates the WebRequester to use.</param>
-        protected EventSource(Uri url, IWebRequesterFactory factory)
+        public EventSource(Uri url, IWebRequesterFactory factory)
         {
             _webRequesterFactory = factory;
             Initialize(url, 0);
@@ -61,7 +67,7 @@ namespace EventSource4Net
         {
             _timeout = timeout;
             Url = url;
-            CurrentState = new DisconnectedState(Url,_webRequesterFactory);
+            CurrentState = new DisconnectedState(Url, _webRequesterFactory, _headers);
             _logger.Info("EventSource created for " + url.ToString());
         }
 
@@ -85,7 +91,7 @@ namespace EventSource4Net
             if (mTokenSource.IsCancellationRequested && CurrentState.State == EventSourceState.CLOSED)
                 return;
 
-            mCurrentState.Run(this.OnEventReceived, mTokenSource.Token).ContinueWith(cs =>
+            mCurrentState.Run(this.OnEventReceived, mTokenSource.Token, _headers).ContinueWith(cs =>
             {
                 CurrentState = cs.Result;
                 Run();

--- a/EventSource4Net/IConnectionState.cs
+++ b/EventSource4Net/IConnectionState.cs
@@ -10,6 +10,6 @@ namespace EventSource4Net
     interface IConnectionState
     {
         EventSourceState State { get; }
-        Task<IConnectionState> Run(Action<ServerSentEvent> MsgReceivedCallback, CancellationToken cancelToken);
+        Task<IConnectionState> Run(Action<ServerSentEvent> MsgReceivedCallback, CancellationToken cancelToken, Dictionary<string, string> headers);
     }
 }

--- a/EventSource4Net/IConnectionState.cs
+++ b/EventSource4Net/IConnectionState.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -10,6 +7,6 @@ namespace EventSource4Net
     interface IConnectionState
     {
         EventSourceState State { get; }
-        Task<IConnectionState> Run(Action<ServerSentEvent> MsgReceivedCallback, CancellationToken cancelToken, Dictionary<string, string> headers);
+        Task<IConnectionState> Run(Action<ServerSentEvent> MsgReceivedCallback, CancellationToken cancelToken);
     }
 }

--- a/EventSource4Net/IWebRequester.cs
+++ b/EventSource4Net/IWebRequester.cs
@@ -9,7 +9,6 @@ namespace EventSource4Net
 {
     public interface IWebRequester
     {
-        Task<IServerResponse> Get(Uri url);
-
+        Task<IServerResponse> Get(Uri url, Dictionary<string, string> headers = null);
     }
 }

--- a/EventSource4Net/WebRequester.cs
+++ b/EventSource4Net/WebRequester.cs
@@ -1,19 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace EventSource4Net
 {
     class WebRequester : IWebRequester
     {
-        public Task<IServerResponse> Get(Uri url)
+        public Task<IServerResponse> Get(Uri url, Dictionary<string, string> headers = null)
         {
             var wreq = (HttpWebRequest)WebRequest.Create(url);
             wreq.Method = "GET";
             wreq.Proxy = null;
+
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                {
+                    wreq.Headers.Add(header.Key, header.Value);
+                }
+            }
 
             var taskResp = Task.Factory.FromAsync<WebResponse>(wreq.BeginGetResponse,
                                                             wreq.EndGetResponse,


### PR DESCRIPTION
Sending headers in the request is necessary for authentication purposes.